### PR TITLE
Fix 2025-11 cruise split: 2511ZZ phantom cruise → 2025-11-33P4 (SALLY…

### DIFF
--- a/ingest_calcofi_ctd-cast.qmd
+++ b/ingest_calcofi_ctd-cast.qmd
@@ -136,6 +136,8 @@ d_meas_type <- read_csv(
 )
 d_flds_rd <- read_csv(glue("{dir_meta}/flds_redefine.csv"), show_col_types = F)
 d_tbls_rd <- read_csv(glue("{dir_meta}/tbls_redefine.csv"), show_col_types = F)
+d_cruise_corrections <- read_csv(
+  glue("{dir_meta}/cruise_key_corrections.csv"), show_col_types = F)
 ```
 
 ## Check for Resumable State
@@ -1026,6 +1028,23 @@ for (tbl in modifies_tables) {
   modifies_pks[[tbl]] <- list(
     pk_col = pk_col,
     keys   = dbGetQuery(con, glue("SELECT {pk_col} FROM {tbl}"))[[1]])
+}
+
+# apply cruise_key corrections for known study-column data quality errors.
+# runs unconditionally so it fires for both fresh runs (YYMMKK keys) and
+# checkpoint-restored runs (already-converted YYYY-MM-NODC keys).
+for (i in seq_len(nrow(d_cruise_corrections))) {
+  n_wrong <- dbGetQuery(con, glue(
+    "SELECT COUNT(*) AS n FROM ctd_raw
+     WHERE cruise_key = '{d_cruise_corrections$cruise_key_raw[i]}'"))$n
+  if (n_wrong > 0) {
+    dbExecute(con, glue(
+      "UPDATE ctd_raw SET cruise_key = '{d_cruise_corrections$cruise_key_correct[i]}'
+       WHERE cruise_key = '{d_cruise_corrections$cruise_key_raw[i]}'"))
+    message(glue(
+      "cruise_key correction: {d_cruise_corrections$cruise_key_raw[i]} → ",
+      "{d_cruise_corrections$cruise_key_correct[i]} ({format(n_wrong, big.mark=',')} rows)"))
+  }
 }
 
 # detect whether cruise_key already in YYYY-MM-NODC format (from checkpoint)

--- a/metadata/calcofi/ctd-cast/cruise_key_corrections.csv
+++ b/metadata/calcofi/ctd-cast/cruise_key_corrections.csv
@@ -1,0 +1,3 @@
+cruise_key_raw,cruise_key_correct,notes
+2511ZZ,2511SR,study column data quality error in 20-2511SR_CTDPrelim: most rows say 2511ZZ but should be 2511SR (SALLY RIDE)
+2025-11-?ZZ?,2025-11-33P4,converted form of 2511ZZ correction (applied when checkpoint has already-converted keys)

--- a/metadata/calcofi/ctd-cast/ctd_zip_urls.csv
+++ b/metadata/calcofi/ctd-cast/ctd_zip_urls.csv
@@ -1,5 +1,6 @@
 url,file_zip,year,month,cruise_key,zip_type
 https://calcofi.org/downloads/2026/20-2601RL_CTDPrelim.zip,20-2601RL_CTDPrelim.zip,2026,1,2601RL,preliminary
+https://calcofi.org/downloads/2026/20-2604SH_CTDPrelim.zip,20-2604SH_CTDPrelim.zip,2026,4,2604SH,preliminary
 https://calcofi.org/downloads/2025/20-2501RL_CTDCast.zip,20-2501RL_CTDCast.zip,2025,1,2501RL,raw
 https://calcofi.org/downloads/2025/20-2501RL_CTDPrelim.zip,20-2501RL_CTDPrelim.zip,2025,1,2501RL,preliminary
 https://calcofi.org/downloads/2025/20-2502RL_CTDCast.zip,20-2502RL_CTDCast.zip,2025,2,2502RL,raw


### PR DESCRIPTION
… RIDE)

Source file 20-2511_CTD_001-047D.csv has Study=2511ZZ for most rows (data quality error) vs the correct 2511SR, causing the per-row study override in d_bind to create a phantom 2025-11-?ZZ? cruise separate from the real 2025-11-33P4 (SALLY RIDE, 39 casts → 1 cast split).

Fix: add metadata/calcofi/ctd-cast/cruise_key_corrections.csv with explicit cruise_key remappings, applied in cross_dataset_bridge before ship_key derivation. Runs unconditionally for both fresh and checkpoint-restored runs (raw YYMMKK and converted YYYY-MM-NODC forms of the bad key are both listed).

Also adds 2604SH preliminary CTD zip URL scraped from calcofi.org.