### PR TITLE
release_database.qmd: build and upload metadata.json sidecar; fix tot…

### DIFF
--- a/.claude/skills/generate-metadata.md
+++ b/.claude/skills/generate-metadata.md
@@ -70,35 +70,39 @@ for (f in files) {
 Format (matching existing pattern from `metadata/swfsc/ichthyo/tbls_redefine.csv`):
 
 ```csv
-table_source,table_new,table_description,include
-{source_table_1},{new_table_1},{description},TRUE
-{source_table_2},{new_table_2},{description},TRUE
+tbl_old,tbl_new,tbl_description
+{source_table_1},{new_table_1},{description}
+{source_table_2},{new_table_2},{description}
 ```
 
 Rules:
-- `table_source`: Original CSV filename (without .csv extension) or table name
-- `table_new`: snake_case name following `{dataset}_{purpose}` convention
-- `table_description`: Brief description of table contents
-- `include`: TRUE to include in ingest, FALSE to skip
+- `tbl_old`: Original CSV filename (without `.csv`) or source table name
+- `tbl_new`: snake_case name following `{dataset}_{purpose}` convention
+- `tbl_description`: **Required** — brief description of table contents.
+  Markdown allowed. Must explain what one row represents.
 
 ### 4. Create `flds_redefine.csv`
 
 Format (matching existing pattern):
 
 ```csv
-table_source,table_new,field_source,field_new,field_type,field_description,field_units,include,is_pk,is_fk,fk_table,fk_field,field_order
-{tbl_src},{tbl_new},{fld_src},{fld_new},{type},{desc},{units},TRUE,FALSE,FALSE,,,1
+tbl_old,tbl_new,fld_old,fld_new,type_old,type_new,order_old,order_new,fld_description,units,notes,mutation
+{tbl_src},{tbl_new},{fld_src},{fld_new},{type_src},{type_new},{ord_src},{ord_new},{desc},{units},{notes},{mutation}
 ```
 
 Rules:
-- `field_source`: Original column name from CSV
-- `field_new`: snake_case name following CalCOFI conventions
-- `field_type`: DuckDB/PostgreSQL type (integer, smallint, double, varchar, date, timestamp, uuid, boolean)
-- `field_units`: SI units where applicable
-- `include`: TRUE to include, FALSE to drop
-- `is_pk`: TRUE if primary key
-- `is_fk`: TRUE if foreign key referencing another table
-- `fk_table`, `fk_field`: Referenced table and field for FKs
+- `fld_old`: Original column name from source CSV
+- `fld_new`: snake_case name following CalCOFI conventions
+- `type_new`: DuckDB type (`INTEGER`, `SMALLINT`, `DOUBLE`, `VARCHAR`, `DATE`, `TIMESTAMP`, `UUID`, `BOOLEAN`)
+- `fld_description`: **Required** for every column. Markdown allowed.
+  Empty descriptions land verbatim in the release `metadata.json` and
+  break downstream catalogs.
+- `units`: **Required** for any numeric/measurement column (e.g. `m`,
+  `degC`, `PSS-78`, `decimal degrees`, `count`). Leave empty only for
+  identifiers (PKs/FKs, `*_key`, `*_id`, `*_uuid`), categorical strings,
+  timestamps, and geometry.
+- `notes`: Optional QA notes (e.g. "renamed from `t_qual` for clarity")
+- `mutation`: Optional SQL/dplyr expression for derived transformations
 
 Standard column name mappings to apply:
 - Latitude → `lat_dec` or `latitude` (type: double)
@@ -160,9 +164,50 @@ Show:
 - Measurement types to add (if any)
 - Dataset metadata row added to `metadata/dataset.csv`
 - Instructions for next steps:
-  1. Review and edit `flds_redefine.csv` (rename decisions, type overrides, include/exclude)
+  1. Review and edit `flds_redefine.csv` (rename decisions, type overrides)
   2. Add new entries to `metadata/measurement_type.csv` if needed
   3. Run `/ingest-new {provider} {dataset}` to scaffold the ingest notebook
+
+### 9. Hand-off completeness check
+
+Before declaring the metadata scaffolding done, verify no row of
+`tbls_redefine.csv` or `flds_redefine.csv` is missing the fields that
+flow into the release `metadata.json` sidecar:
+
+```r
+librarian::shelf(readr, dplyr, glue, here, quiet = T)
+provider <- "{provider}"; dataset <- "{dataset}"
+dir_meta <- here(glue("metadata/{provider}/{dataset}"))
+
+t <- read_csv(file.path(dir_meta, "tbls_redefine.csv"), show_col_types = F)
+f <- read_csv(file.path(dir_meta, "flds_redefine.csv"), show_col_types = F)
+
+bad_t <- t |> filter(is.na(tbl_description) | tbl_description == "")
+bad_d <- f |> filter(is.na(fld_description) | fld_description == "")
+bad_u <- f |>
+  filter(
+    !grepl("(_id|_key|_uuid|_qual|_flag|_status|_at|datetime|date|geom)$", fld_new),
+    !type_new %in% c("VARCHAR", "TEXT", "TIMESTAMP", "DATE", "BOOLEAN", "UUID"),
+    is.na(units) | units == "")
+
+if (nrow(bad_t) + nrow(bad_d) + nrow(bad_u) > 0) {
+  cat(glue("\nMETADATA GAPS:\n"))
+  cat(glue("  tables missing tbl_description: {nrow(bad_t)}\n"))
+  cat(glue("  fields missing fld_description: {nrow(bad_d)}\n"))
+  cat(glue("  numeric fields missing units:   {nrow(bad_u)}\n"))
+  print(bind_rows(bad_t |> mutate(gap = "tbl_description"),
+                  bad_d |> mutate(gap = "fld_description"),
+                  bad_u |> mutate(gap = "units")) |>
+        select(any_of(c("tbl_new", "fld_new", "type_new", "gap"))))
+} else {
+  cat("All required descriptions and units populated.\n")
+}
+```
+
+Resolve every gap (or justify it in the row's `notes` column) before
+moving on to `/ingest-new`. The release `metadata.json` is the user-
+facing source of truth — empty `description_md` / `units` ship straight
+to consumers (calcofi4r `cc_describe_table()`, `cc_db_catalog()`).
 
 ## Example
 

--- a/.claude/skills/ingest-new.md
+++ b/.claude/skills/ingest-new.md
@@ -242,3 +242,35 @@ Show the user:
   1. Fill in TODO sections with dataset-specific transforms
   2. Run the notebook to test
   3. Run `/validate-ingest {provider} {dataset}` to verify
+
+### 10. Post-ingest metadata.json completeness scan
+
+After the first successful render of the new ingest notebook (which runs
+`finalize_ingest()` → `build_metadata_json()`), scan the produced sidecar
+for empty descriptions and units. These ship verbatim to the release
+`metadata.json` and on to calcofi4r `cc_describe_table()` /
+`cc_db_catalog()`, so empties should be surfaced as TODOs, not ignored.
+
+```r
+librarian::shelf(jsonlite, glue, here, quiet = T)
+provider <- "{provider}"; dataset <- "{dataset}"
+meta_path <- here(glue("data/parquet/{provider}_{dataset}/metadata.json"))
+m <- fromJSON(meta_path, simplifyVector = FALSE)
+
+empty_tbl_desc <- Filter(function(t) !nzchar(t$description_md %||% ""), m$tables)
+empty_col_desc <- Filter(function(c) !nzchar(c$description_md %||% ""), m$columns)
+empty_col_unit <- Filter(function(c) is.null(c$units),                   m$columns)
+
+cat(glue("\nmetadata.json gaps for {provider}_{dataset}:\n"))
+cat(glue("  tables with empty description_md: {length(empty_tbl_desc)}\n"))
+cat(glue("  columns with empty description_md: {length(empty_col_desc)}\n"))
+cat(glue("  columns with NULL units (review numeric only): {length(empty_col_unit)}\n"))
+if (length(empty_tbl_desc) > 0)
+  cat("  ", paste(names(empty_tbl_desc), collapse = ", "), "\n")
+if (length(empty_col_desc) > 0)
+  cat("  ", paste(head(names(empty_col_desc), 20), collapse = ", "),
+      if (length(empty_col_desc) > 20) glue(" (+{length(empty_col_desc)-20} more)") else "", "\n")
+```
+
+Report the counts back to the user along with the top offenders so they
+can backfill `flds_redefine.csv` and re-run.

--- a/.claude/skills/publish-template.md
+++ b/.claude/skills/publish-template.md
@@ -119,7 +119,45 @@ tar_target(
 )
 ```
 
-### 6. Present results
+### 6. Post-release sidecar smoke test
+
+After `release_database.qmd` has published a release to GCS, verify the
+`metadata.json` sidecar parses cleanly and covers every table named in
+`catalog.json`. The publish workflow consumes both sidecars when
+assembling EML / datasets.xml, so a drift between them is a publish
+blocker.
+
+```r
+librarian::shelf(jsonlite, glue, here, quiet = T)
+v <- readLines("https://storage.googleapis.com/calcofi-db/ducklake/releases/latest.txt", warn = FALSE)
+base <- glue("https://storage.googleapis.com/calcofi-db/ducklake/releases/{v}")
+
+cat_json  <- fromJSON(file.path(base, "catalog.json"))
+meta_json <- fromJSON(file.path(base, "metadata.json"), simplifyVector = FALSE)
+
+cat_tbls  <- cat_json$tables$name
+meta_tbls <- names(meta_json$tables)
+
+missing_in_meta <- setdiff(cat_tbls, meta_tbls)
+missing_in_cat  <- setdiff(meta_tbls, cat_tbls)
+
+cat(glue("Release: {v}\n"))
+cat(glue("catalog.json tables:  {length(cat_tbls)}\n"))
+cat(glue("metadata.json tables: {length(meta_tbls)}\n"))
+cat(glue("schema_version: {meta_json$schema_version} (expect 1.1)\n"))
+cat(glue("missing from metadata.json: {length(missing_in_meta)}\n"))
+if (length(missing_in_meta) > 0) cat("  ", paste(missing_in_meta, collapse=", "), "\n")
+cat(glue("missing from catalog.json:  {length(missing_in_cat)}\n"))
+if (length(missing_in_cat)  > 0) cat("  ", paste(missing_in_cat,  collapse=", "), "\n")
+stopifnot(meta_json$schema_version == "1.1",
+          length(missing_in_meta) == 0)
+```
+
+Abort the publish if either set-diff is non-empty — the
+`release_database.qmd` step needs to be re-run to repair the sidecar
+before any portal sees stale metadata.
+
+### 7. Present results
 
 Show the user:
 - Created file path

--- a/.claude/skills/validate-ingest.md
+++ b/.claude/skills/validate-ingest.md
@@ -258,7 +258,64 @@ if (length(results$warnings) > 0) cat("Warnings:\n", paste("-", results$warnings
 # save any orphan/invalid rows to data/flagged/
 ```
 
-### 7. Present results
+### 7. Validate metadata.json completeness
+
+Open `data/parquet/{provider}_{dataset}/metadata.json` and enforce three
+hard assertions. Failures should appear in the validation report as
+**errors** (not warnings) since these fields are user-facing in
+`cc_describe_table()` and `cc_db_catalog()`.
+
+```r
+librarian::shelf(jsonlite, glue, here, dplyr, quiet = T)
+provider <- "{provider}"; dataset <- "{dataset}"
+meta_path <- here(glue("data/parquet/{provider}_{dataset}/metadata.json"))
+stopifnot(file.exists(meta_path))
+m <- fromJSON(meta_path, simplifyVector = FALSE)
+
+# (a) every table has non-empty description_md
+no_tbl_desc <- names(Filter(function(t) !nzchar(t$description_md %||% ""), m$tables))
+
+# (b) every non-identifier, non-geometry, non-qual column has non-empty description_md
+is_identifier <- function(col) grepl("(_id|_key|_uuid|_qual|_flag|_status|_at|geom|datetime|date)$", col)
+no_col_desc <- vapply(names(m$columns), function(k) {
+  col <- sub("^[^.]+\\.", "", k)
+  !is_identifier(col) && !nzchar(m$columns[[k]]$description_md %||% "")
+}, logical(1))
+no_col_desc <- names(m$columns)[no_col_desc]
+
+# (c) measurement_value / avg / stddev columns must have a unit (either inline
+#     or via the measurement_type CSV)
+mt <- read.csv(here("metadata/measurement_type.csv"), stringsAsFactors = FALSE)
+measurement_cols <- grep("\\.(measurement_value|avg|stddev|value)$",
+                         names(m$columns), value = TRUE)
+no_unit <- vapply(measurement_cols, function(k) {
+  is.null(m$columns[[k]]$units) || !nzchar(m$columns[[k]]$units)
+}, logical(1))
+no_unit <- measurement_cols[no_unit]
+# any of these MUST be paired with a measurement_type column whose values are
+# all registered in measurement_type.csv. Flag if not.
+
+cat(glue("\nMetadata completeness for {provider}_{dataset}:\n"))
+cat(glue("  tables with empty description_md: {length(no_tbl_desc)}\n"))
+cat(glue("  non-identifier columns with empty description_md: {length(no_col_desc)}\n"))
+cat(glue("  measurement columns with NULL units: {length(no_unit)}\n"))
+
+# Hard fail if any tables are undocumented or > 25% of non-ID columns are undocumented
+status <- "PASS"
+if (length(no_tbl_desc) > 0) status <- "ERROR"
+n_doc_cols <- sum(!vapply(names(m$columns), function(k) {
+  col <- sub("^[^.]+\\.", "", k); is_identifier(col)
+}, logical(1)))
+if (n_doc_cols > 0 && length(no_col_desc) / n_doc_cols > 0.25) status <- "ERROR"
+if (length(no_unit) > 0) status <- "ERROR"
+cat(glue("  metadata.json status: {status}\n"))
+```
+
+Include the lists of offending tables/columns in the report so the user
+has a copy-paste TODO for the underlying `tbls_redefine.csv` and
+`flds_redefine.csv`.
+
+### 8. Present results
 
 Show the validation report and recommend actions:
 - For errors: specific fix instructions

--- a/metadata/release_columns.csv
+++ b/metadata/release_columns.csv
@@ -1,0 +1,39 @@
+table,column,name_long,units,description_md
+cruise_summary,cruise_key,Cruise Key,,Natural key YYYY-MM-NODC (e.g. 1998-02-33JD).
+cruise_summary,year,Year,,Cruise year extracted from date_ym.
+cruise_summary,month,Month,,Cruise month extracted from date_ym.
+cruise_summary,ship_name,Ship Name,,Ship name as resolved against NODC ship registry.
+cruise_summary,ship_nodc,Ship NODC,,NODC ship code.
+cruise_summary,ichthyo,Ichthyo Sites,count,Distinct sites sampled by SWFSC ichthyo on this cruise.
+cruise_summary,bottle,Bottle Sites,count,Distinct sites sampled by CalCOFI bottle casts on this cruise.
+cruise_summary,ctd_cast,CTD Sites,count,Distinct sites sampled by CTD casts on this cruise.
+cruise_summary,dic,DIC Sites,count,Distinct sites with NCEI DIC samples on this cruise.
+_spatial,layer,Layer,,Spatial layer slug from metadata/spatial_layers.csv (e.g. ca_county_boundaries).
+_spatial,feature_id,Feature ID,,Stable feature identifier within the layer.
+_spatial,geom,Geometry,,Feature geometry in WGS84 (EPSG:4326).
+_spatial_attr,layer,Layer,,Spatial layer slug matching _spatial.layer.
+_spatial_attr,feature_id,Feature ID,,Feature identifier matching _spatial.feature_id.
+_spatial_attr,attr_name,Attribute Name,,Source-attribute column name.
+_spatial_attr,attr_value,Attribute Value,,Source-attribute value cast to text.
+ctd_cast,cast_uuid,Cast UUID,,UUID for the CTD cast (deterministic per source row).
+ctd_cast,cruise_key,Cruise Key,,Cruise natural key YYYY-MM-NODC.
+ctd_cast,site_key,Site Key,,Line+Station composite key.
+ctd_cast,datetime_utc,Datetime UTC,UTC,Start datetime of the cast.
+ctd_cast,latitude,Latitude,decimal degrees,Cast latitude (WGS84).
+ctd_cast,longitude,Longitude,decimal degrees,Cast longitude (WGS84).
+ctd_cast,depth_m,Depth,m,Scan depth.
+ctd_cast,pressure_dbar,Pressure,dbar,Scan pressure.
+ctd_thin,cast_uuid,Cast UUID,,UUID for the CTD cast (one direction kept per cast).
+ctd_thin,cruise_key,Cruise Key,,Cruise natural key YYYY-MM-NODC.
+ctd_thin,site_key,Site Key,,Line+Station composite key.
+ctd_thin,datetime_utc,Datetime UTC,UTC,Cast datetime.
+ctd_thin,depth_m,Depth,m,Sample depth after adaptive thinning.
+ctd_thin,measurement_type,Measurement Type,,Canonical measurement type (see measurement_type.is_canonical).
+ctd_thin,measurement_value,Measurement Value,,Value in the measurement_type's canonical units.
+ctd_summary,site_key,Site Key,,Line+Station composite key.
+ctd_summary,datetime_utc,Datetime UTC,UTC,Cast datetime.
+ctd_summary,depth_m,Depth,m,Aggregation depth bin.
+ctd_summary,measurement_type,Measurement Type,,Canonical measurement type.
+ctd_summary,avg,Average,,Mean of replicate scans within the bin.
+ctd_summary,stddev,Std Dev,,Sample standard deviation across replicate scans (0 when n=1).
+ctd_summary,n_obs,N Obs,count,Number of scans aggregated into the bin.

--- a/metadata/release_tables.csv
+++ b/metadata/release_tables.csv
@@ -1,0 +1,7 @@
+table,name_long,description_md,provider,dataset
+cruise_summary,Cruise Summary,Per-cruise rollup with year/month/ship and counts of sites sampled across ichthyo bottle CTD and DIC. Built in release_database.qmd from cruise + ship and site/casts/ctd_cast/dic_sample. Used by the CalCOFI cruises Shiny app.,calcofi,calcofi-db-release
+_spatial,Spatial Layers,Geometries for ancillary spatial layers (CA jurisdictions NOAA boundaries marine protected areas etc.) keyed by layer + feature_id. Sourced from metadata/spatial_layers.csv. Companion to _spatial_attr.,calcofi,spatial
+_spatial_attr,Spatial Layer Attributes,Non-geometry attributes for features in _spatial in long form (layer feature_id attr_name attr_value). Allows attribute schemas to differ across layers without column proliferation.,calcofi,spatial
+ctd_cast,CTD Cast,Per-cast CTD profile at scan-level granularity (one row per pressure scan along a cast). Source: CalCOFI CTD ZIP archives. Larger sibling of ctd_thin; ctd_thin is the canonical release table.,calcofi,ctd-cast
+ctd_thin,CTD Thin,Adaptively-thinned CTD profile (one cast direction canonical measurement types ~10 m depth grid plus Douglas-Peucker-preserved inflections). Headline CTD table for analysis.,calcofi,ctd-cast
+ctd_summary,CTD Summary,CTD measurements aggregated to canonical depth bins with avg/stddev/n_obs per site_key + datetime + depth_m + measurement_type.,calcofi,ctd-cast

--- a/release_database.qmd
+++ b/release_database.qmd
@@ -680,11 +680,24 @@ for (pq in derived_local) {
 tables_df <- freeze_stats |>
   select(name = table, rows, partitioned)
 
+# sum bytes of the uploaded parquet tree on GCS
+du_out <- system2(
+  gcloud,
+  c("storage", "du", "--summarize",
+    glue("gs://{gcs_bucket}/{gcs_release}/parquet/")),
+  stdout = TRUE, stderr = TRUE)
+total_bytes <- suppressWarnings(
+  as.numeric(sub("\\s.*$", "", trimws(du_out[1]))))
+if (is.na(total_bytes)) {
+  warning(glue("Could not parse gcloud storage du output: {paste(du_out, collapse='; ')}"))
+  total_bytes <- 0
+}
+
 catalog <- list(
   version      = release_version,
   release_date = as.character(Sys.Date()),
   total_rows   = sum(tables_df$rows, na.rm = TRUE),
-  total_size   = 0,
+  total_size   = total_bytes,
   tables       = tables_df)
 catalog_path <- file.path(dir_frozen, "catalog.json")
 jsonlite::write_json(catalog, catalog_path, auto_unbox = TRUE, pretty = TRUE)
@@ -702,6 +715,31 @@ rels_json <- file.path(dir_frozen, "relationships.json")
 if (file.exists(rels_json))
   put_gcs_file(rels_json,
     glue("gs://{gcs_bucket}/{gcs_release}/relationships.json"))
+
+# build and upload metadata.json (table/column descriptions + units)
+meta_paths <- c(
+  here("data/parquet/swfsc_ichthyo/metadata.json"),
+  here("data/parquet/calcofi_bottle/metadata.json"),
+  here("data/parquet/calcofi_ctd-cast/metadata.json"),
+  here("data/parquet/calcofi_dic/metadata.json")
+)
+meta_paths <- meta_paths[file.exists(meta_paths)]
+
+meta_json_path <- file.path(dir_frozen, "metadata.json")
+if (length(meta_paths) > 0) {
+  merge_metadata_json(
+    paths                = meta_paths,
+    output_path          = meta_json_path,
+    release_version      = release_version,
+    release_tables_csv   = here("metadata/release_tables.csv"),
+    release_columns_csv  = here("metadata/release_columns.csv"),
+    measurement_type_csv = here("metadata/measurement_type.csv"),
+    dataset_csv          = here("metadata/dataset.csv"))
+  put_gcs_file(meta_json_path,
+    glue("gs://{gcs_bucket}/{gcs_release}/metadata.json"))
+} else {
+  warning("No per-ingest metadata.json files found; skipping release metadata.json")
+}
 
 # 4. update versions.json and latest.txt
 # discover all releases from GCS and rebuild versions.json


### PR DESCRIPTION
…al_size

Adds a metadata.json sidecar to each frozen release alongside catalog.json and relationships.json. Built via the new calcofi4db::merge_metadata_json() over the per-ingest metadata.json files in data/parquet/*/, with overlays from new
metadata/release_tables.csv and metadata/release_columns.csv covering release-only tables (cruise_summary, _spatial, _spatial_attr, ctd_*).

Fixes the hardcoded total_size: 0 in catalog.json by summing the uploaded GCS parquet tree via `gcloud storage du --summarize`.

.claude/skills updates:
- generate-metadata: correct the documented tbls/flds_redefine.csv schema (was using non-existent table_source/field_source columns); require tbl_description and fld_description on every row; require units on every numeric/measurement column; add a hand-off completeness check.
- ingest-new: add a post-render scan of the per-ingest metadata.json for empty description_md / NULL units, reported as TODOs.
- validate-ingest: add metadata.json completeness assertions (errors, not warnings) for tables without descriptions, columns without descriptions, and measurement columns without units.
- publish-template: add a release-sidecar smoke test that asserts schema_version 1.1 and that catalog.json/metadata.json table sets match.