### PR TITLE
Derive measurement_type → dataset(s) membership; regen v2026.06.26 sidecar

### DIFF
--- a/data/releases/v2026.06.26/metadata.json
+++ b/data/releases/v2026.06.26/metadata.json
@@ -4124,1057 +4124,793 @@
       "description": "Water temperature (QC'd)",
       "units": "degC",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "salinity": {
       "description": "Salinity - Practical Salinity Scale 1978 (QC'd)",
       "units": "PSS-78",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "oxygen_ml_l": {
       "description": "Dissolved oxygen (QC'd)",
       "units": "ml/L",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "sigma_theta": {
       "description": "Potential density (Sigma Theta)",
       "units": "kg/m3",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "oxygen_saturation": {
       "description": "Oxygen percent saturation",
       "units": "%",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "oxygen_umol_kg": {
       "description": "Dissolved oxygen (QC'd)",
       "units": "umol/kg",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "chlorophyll_a": {
       "description": "Chlorophyll-a measured fluorometrically",
       "units": "ug/L",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "phaeopigment": {
       "description": "Phaeopigment measured fluorometrically",
       "units": "ug/L",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "phosphate": {
       "description": "Phosphate concentration",
       "units": "umol/L",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "silicate": {
       "description": "Silicate concentration",
       "units": "umol/L",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "nitrite": {
       "description": "Nitrite concentration",
       "units": "umol/L",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "nitrate": {
       "description": "Nitrate concentration",
       "units": "umol/L",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "ammonia": {
       "description": "Ammonia concentration (QC'd)",
       "units": "umol/L",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "c14_rep1": {
       "description": "14C assimilation replicate 1",
       "units": "mgC/m3/hld",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "c14_rep2": {
       "description": "14C assimilation replicate 2",
       "units": "mgC/m3/hld",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "c14_dark": {
       "description": "14C assimilation dark/control bottle",
       "units": "mgC/m3/hld",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "c14_mean": {
       "description": "Mean 14C assimilation of replicates 1 and 2",
       "units": "mgC/m3/hld",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "light_pct": {
       "description": "Light intensity of incubation tubes",
       "units": "%",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "r_depth": {
       "description": "Reported depth from pressure (pre-QC)",
       "units": "m",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "r_temperature": {
       "description": "Reported potential temperature (pre-QC)",
       "units": "degC",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "r_salinity_sva": {
       "description": "Reported Specific Volume Anomaly (pre-QC); WARNING: different parameter/scale than salinity PSS-78",
       "units": "10^-8 m3/kg",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "r_dynamic_height": {
       "description": "Reported dynamic height (no QC'd counterpart)",
       "units": "dyn m",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "r_ammonium": {
       "description": "Reported ammonium concentration (pre-QC)",
       "units": "umol/L",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "r_oxygen_umol_kg": {
       "description": "Reported oxygen (pre-QC)",
       "units": "umol/kg",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "dic_rep1": {
       "description": "Dissolved inorganic carbon replicate 1",
       "units": "umol/kg",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "dic_rep2": {
       "description": "Dissolved inorganic carbon replicate 2",
       "units": "umol/kg",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "alkalinity_rep1": {
       "description": "Total alkalinity replicate 1",
       "units": "umol/kg",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "alkalinity_rep2": {
       "description": "Total alkalinity replicate 2",
       "units": "umol/kg",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "ph_rep1": {
       "description": "pH replicate 1",
       "units": "pH",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "ph_rep2": {
       "description": "pH replicate 2",
       "units": "pH",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "wave_direction": {
       "description": "Wave direction (abbreviated 360 degree azimuth)",
       "units": "degrees",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "wave_height": {
       "description": "Wave height",
       "units": "feet",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "wave_period": {
       "description": "Wave period",
       "units": "seconds",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "wind_direction": {
       "description": "Wind direction (abbreviated 360 degree azimuth)",
       "units": "degrees",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "wind_speed": {
       "description": "Wind speed",
       "units": "knots",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "barometric_pressure": {
       "description": "Barometric pressure",
       "units": "millibars",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "dry_air_temp": {
       "description": "Dry air temperature from sling psychrometer",
       "units": "degC",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "wet_air_temp": {
       "description": "Wet air temperature from sling psychrometer",
       "units": "degC",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "weather_code": {
       "description": "WMO weather code (WMO 4501)",
       "units": null,
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "cloud_type": {
       "description": "WMO cloud type code (WMO 0500)",
       "units": null,
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "cloud_amount": {
       "description": "Cloud amount in oktas (WMO 2700)",
       "units": "oktas",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "visibility": {
       "description": "WMO visibility code (WMO 4300)",
       "units": null,
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "secchi_depth": {
       "description": "Secchi disk depth",
       "units": "meters",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "water_color": {
       "description": "Water color on Forel-Ule scale",
       "units": "Forel-Ule",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_bottle"
-      ]
+      "datasets": ["calcofi_bottle"]
     },
     "stage": {
       "description": "Egg or larva developmental stage",
       "units": null,
       "is_canonical": true,
-      "datasets": [
-        "swfsc_ichthyo"
-      ]
+      "datasets": ["swfsc_ichthyo"]
     },
     "size": {
       "description": "Larva size measurement",
       "units": "mm",
       "is_canonical": true,
-      "datasets": [
-        "swfsc_ichthyo"
-      ]
+      "datasets": ["swfsc_ichthyo"]
     },
     "tally": {
       "description": "Specimen count",
       "units": null,
       "is_canonical": true,
-      "datasets": [
-        "swfsc_ichthyo"
-      ]
+      "datasets": ["swfsc_ichthyo"]
     },
     "temperature_1": {
       "description": "Temperature sensor 1",
       "units": "degC",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "temperature_2": {
       "description": "Temperature sensor 2",
       "units": "degC",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "temperature_ave": {
       "description": "Average temperature",
       "units": "degC",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "potential_temperature_1": {
       "description": "Potential temperature sensor 1",
       "units": "degC",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "potential_temperature_2": {
       "description": "Potential temperature sensor 2",
       "units": "degC",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "salinity_1": {
       "description": "Salinity sensor 1",
       "units": "PSU",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "salinity_1_corr": {
       "description": "Salinity sensor 1 cruise-corrected",
       "units": "PSU",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "salinity_2": {
       "description": "Salinity sensor 2",
       "units": "PSU",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "salinity_2_corr": {
       "description": "Salinity sensor 2 cruise-corrected",
       "units": "PSU",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "salinity_ave_corr": {
       "description": "Average salinity corrected",
       "units": "PSU",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "salinity_btl": {
       "description": "Bottle salinity",
       "units": "PSU",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_ml_l_1": {
       "description": "Dissolved oxygen sensor 1",
       "units": "ml/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_ml_l_1_cruise_corr": {
       "description": "DO sensor 1 cruise-corrected",
       "units": "ml/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_ml_l_1_sta_corr": {
       "description": "DO sensor 1 station-corrected",
       "units": "ml/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_ml_l_2": {
       "description": "Dissolved oxygen sensor 2",
       "units": "ml/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_ml_l_2_cruise_corr": {
       "description": "DO sensor 2 cruise-corrected",
       "units": "ml/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_ml_l_2_sta_corr": {
       "description": "DO sensor 2 station-corrected",
       "units": "ml/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_ml_l_ave_sta_corr": {
       "description": "DO average station-corrected",
       "units": "ml/L",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_umol_kg_1": {
       "description": "DO sensor 1",
       "units": "umol/kg",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_umol_kg_1_cruise_corr": {
       "description": "DO sensor 1 cruise-corrected",
       "units": "umol/kg",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_umol_kg_1_sta_corr": {
       "description": "DO sensor 1 station-corrected",
       "units": "umol/kg",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_umol_kg_2": {
       "description": "DO sensor 2",
       "units": "umol/kg",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_umol_kg_2_cruise_corr": {
       "description": "DO sensor 2 cruise-corrected",
       "units": "umol/kg",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_umol_kg_2_sta_corr": {
       "description": "DO sensor 2 station-corrected",
       "units": "umol/kg",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_umol_kg_ave_sta_corr": {
       "description": "DO average station-corrected",
       "units": "umol/kg",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_saturation_1": {
       "description": "Oxygen saturation sensor 1",
       "units": "%",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_saturation_2": {
       "description": "Oxygen saturation sensor 2",
       "units": "%",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_btl_ml_l": {
       "description": "Bottle dissolved oxygen",
       "units": "ml/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "oxygen_btl_umol_kg": {
       "description": "Bottle dissolved oxygen",
       "units": "umol/kg",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "fluorescence_v": {
       "description": "Fluorescence voltage",
       "units": "V",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "est_chlorophyll_a_cruise_corr": {
       "description": "Est. chlorophyll-a cruise-corrected",
       "units": "ug/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "est_chlorophyll_a_sta_corr": {
       "description": "Est. chlorophyll-a station-corrected",
       "units": "ug/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "isus_v": {
       "description": "ISUS nitrate voltage",
       "units": "V",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "est_nitrate_cruise_corr": {
       "description": "Est. nitrate cruise-corrected",
       "units": "umol/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "est_nitrate_sta_corr": {
       "description": "Est. nitrate station-corrected",
       "units": "umol/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "sigma_theta_1": {
       "description": "Potential density sensor 1",
       "units": "kg/m3",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "sigma_theta_2": {
       "description": "Potential density sensor 2",
       "units": "kg/m3",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "dynamic_height": {
       "description": "Dynamic height",
       "units": "dyn m",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "specific_volume_anomaly": {
       "description": "Specific volume anomaly",
       "units": "10^-8 m3/kg",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "par": {
       "description": "Photosynthetically active radiation",
       "units": "uE/m2/s",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "spar": {
       "description": "Surface PAR",
       "units": "uE/m2/s",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "beam_attenuation": {
       "description": "Beam attenuation coefficient",
       "units": "1/m",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "transmissometer": {
       "description": "Light transmissometer",
       "units": "%",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "ph": {
       "description": "pH",
       "units": "pH",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "btl_depth": {
       "description": "Bottle trip depth",
       "units": "m",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "btl_temperature": {
       "description": "Bottle temperature",
       "units": "degC",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "btl_chlorophyll_a": {
       "description": "Bottle chlorophyll-a",
       "units": "ug/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "btl_phaeopigment": {
       "description": "Bottle phaeopigment",
       "units": "ug/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "btl_nitrate": {
       "description": "Bottle nitrate",
       "units": "umol/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "btl_nitrite": {
       "description": "Bottle nitrite",
       "units": "umol/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "btl_ammonium": {
       "description": "Bottle ammonium",
       "units": "umol/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "btl_phosphate": {
       "description": "Bottle phosphate",
       "units": "umol/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "btl_silicate": {
       "description": "Bottle silicate",
       "units": "umol/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "pressure": {
       "description": "Pressure",
       "units": "dbar",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_ctd-cast"
-      ]
+      "datasets": ["calcofi_ctd-cast"]
     },
     "dic": {
       "description": "Dissolved inorganic carbon",
       "units": "umol/kg",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_dic"
-      ]
+      "datasets": ["calcofi_dic"]
     },
     "alkalinity": {
       "description": "Total alkalinity",
       "units": "umol/kg",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_dic"
-      ]
+      "datasets": ["calcofi_dic"]
     },
     "ctdtemp_its90": {
       "description": "CTD temperature (ITS-90 scale)",
       "units": "degC",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_dic"
-      ]
+      "datasets": ["calcofi_dic"]
     },
     "salinity_pss78": {
       "description": "Practical salinity (PSS-78)",
       "units": "PSS-78",
       "is_canonical": true,
-      "datasets": [
-        "calcofi_dic"
-      ]
+      "datasets": ["calcofi_dic"]
     },
     "euphausiid_abundance": {
       "description": "Euphausiid (krill) abundance per net tow. PROVISIONAL: units and taxonomic scope unconfirmed (see questions Q01, Q02).",
       "units": "count/1000m3",
       "is_canonical": false,
-      "datasets": [
-        "cce-lter_euphausiids"
-      ]
+      "datasets": ["cce-lter_euphausiids"]
     },
     "sardine_eggs": {
       "description": "Sardine egg count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "swfsc_cufes"
-      ]
+      "datasets": ["swfsc_cufes"]
     },
     "anchovy_eggs": {
       "description": "Northern anchovy egg count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "swfsc_cufes"
-      ]
+      "datasets": ["swfsc_cufes"]
     },
     "jack_mackerel_eggs": {
       "description": "Jack mackerel egg count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "swfsc_cufes"
-      ]
+      "datasets": ["swfsc_cufes"]
     },
     "hake_eggs": {
       "description": "Pacific hake egg count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "swfsc_cufes"
-      ]
+      "datasets": ["swfsc_cufes"]
     },
     "squid_eggs": {
       "description": "Squid egg count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "swfsc_cufes"
-      ]
+      "datasets": ["swfsc_cufes"]
     },
     "other_fish_eggs": {
       "description": "Other fish egg count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "swfsc_cufes"
-      ]
+      "datasets": ["swfsc_cufes"]
     },
     "total_phyllosoma": {
       "description": "Total phyllosoma larvae count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phyllosoma"
-      ]
+      "datasets": ["calcofi_phyllosoma"]
     },
     "phyllosoma_stage_1": {
       "description": "Phyllosoma stage 1 count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phyllosoma"
-      ]
+      "datasets": ["calcofi_phyllosoma"]
     },
     "phyllosoma_stage_2": {
       "description": "Phyllosoma stage 2 count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phyllosoma"
-      ]
+      "datasets": ["calcofi_phyllosoma"]
     },
     "phyllosoma_stage_3": {
       "description": "Phyllosoma stage 3 count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phyllosoma"
-      ]
+      "datasets": ["calcofi_phyllosoma"]
     },
     "phyllosoma_stage_4": {
       "description": "Phyllosoma stage 4 count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phyllosoma"
-      ]
+      "datasets": ["calcofi_phyllosoma"]
     },
     "phyllosoma_stage_5": {
       "description": "Phyllosoma stage 5 count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phyllosoma"
-      ]
+      "datasets": ["calcofi_phyllosoma"]
     },
     "phyllosoma_stage_6": {
       "description": "Phyllosoma stage 6 count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phyllosoma"
-      ]
+      "datasets": ["calcofi_phyllosoma"]
     },
     "phyllosoma_stage_7": {
       "description": "Phyllosoma stage 7 count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phyllosoma"
-      ]
+      "datasets": ["calcofi_phyllosoma"]
     },
     "phyllosoma_stage_8": {
       "description": "Phyllosoma stage 8 count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phyllosoma"
-      ]
+      "datasets": ["calcofi_phyllosoma"]
     },
     "phyllosoma_stage_9": {
       "description": "Phyllosoma stage 9 count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phyllosoma"
-      ]
+      "datasets": ["calcofi_phyllosoma"]
     },
     "phyllosoma_stage_10": {
       "description": "Phyllosoma stage 10 count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phyllosoma"
-      ]
+      "datasets": ["calcofi_phyllosoma"]
     },
     "phyllosoma_stage_11": {
       "description": "Phyllosoma stage 11 count",
       "units": "count",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phyllosoma"
-      ]
+      "datasets": ["calcofi_phyllosoma"]
     },
     "phytoplankton_abundance": {
       "description": "Phytoplankton abundance by inverted-microscope count (cells/L)",
       "units": "cells/L",
       "is_canonical": false,
-      "datasets": [
-        "calcofi_phytoplankton"
-      ]
+      "datasets": ["calcofi_phytoplankton"]
     },
     "zooplankton_abundance": {
       "description": "Zooplankton numerical abundance (volumetric density) per net tow, by higher taxon. Raw (uncorrected for net type).",
       "units": "count/1000m3",
       "is_canonical": true,
-      "datasets": [
-        "cce-lter_zoodb"
-      ]
+      "datasets": ["cce-lter_zoodb"]
     },
     "zooplankton_abundance_areal": {
       "description": "Zooplankton areal abundance (depth-integrated density) per net tow, by higher taxon. Raw (uncorrected).",
       "units": "count/m2",
       "is_canonical": false,
-      "datasets": [
-        "cce-lter_zoodb"
-      ]
+      "datasets": ["cce-lter_zoodb"]
     },
     "zooplankton_biomass_carbon": {
       "description": "Zooplankton carbon biomass per net tow, by higher taxon. Raw (uncorrected for net type).",
       "units": "mgC/m2",
       "is_canonical": true,
-      "datasets": [
-        "cce-lter_zoodb"
-      ]
+      "datasets": ["cce-lter_zoodb"]
     },
     "zooscan_abundance": {
       "description": "Zooplankton areal abundance from ZooScan optical imaging, by image-classified bioclass.",
       "units": "count/m2",
       "is_canonical": true,
-      "datasets": [
-        "cce-lter_zooscan"
-      ]
+      "datasets": ["cce-lter_zooscan"]
     },
     "zooscan_biomass_carbon": {
       "description": "Estimated zooplankton carbon biomass from ZooScan optical imaging, by bioclass.",
       "units": "mgC/m2",
       "is_canonical": true,
-      "datasets": [
-        "cce-lter_zooscan"
-      ]
+      "datasets": ["cce-lter_zooscan"]
     },
     "zooscan_feret_diameter": {
       "description": "Mean Feret diameter (organism size) from ZooScan optical imaging, by bioclass.",
       "units": "mm",
       "is_canonical": false,
-      "datasets": [
-        "cce-lter_zooscan"
-      ]
+      "datasets": ["cce-lter_zooscan"]
     },
     "zooscan_carbon_individual": {
       "description": "Mean individual carbon content from ZooScan optical imaging, by bioclass.",
       "units": "ugC",
       "is_canonical": false,
-      "datasets": [
-        "cce-lter_zooscan"
-      ]
+      "datasets": ["cce-lter_zooscan"]
     }
   },
   "contributions": {

--- a/data/releases/v2026.06.26/test_results.json
+++ b/data/releases/v2026.06.26/test_results.json
@@ -1,8 +1,8 @@
 {
   "release_version": "v2026.06.26",
-  "tested_at": "2026-06-26T17:49:30Z",
-  "n_pass": 3,
-  "n_fail": 6,
+  "tested_at": "2026-06-26T18:01:51Z",
+  "n_pass": 9,
+  "n_fail": 0,
   "n_skip": 4,
   "results": [
     {
@@ -32,65 +32,65 @@
     {
       "query": "browse/cruises.md",
       "label": "cruises",
-      "status": "fail",
-      "ms": 879.1,
-      "error": "Binder Error: Referenced column \"datetime_utc\" not found in FROM clause!\nCandidate bindings: \"datetime_start_utc\", \"latitude\", \"data_type\", \"distance\", \"data_or\"\n\nLINE 9:   WHERE datetime_utc BETWEEN TIMESTAMP '1949-01-01' AND TIMESTAMP...\n                ^\nℹ Context: rapi_prepare\nℹ Error type: BINDER"
+      "status": "pass",
+      "rows": 200,
+      "ms": 2335.8
     },
     {
       "query": "browse/measurement-types.md",
       "label": "measurement types",
       "status": "pass",
       "rows": 102,
-      "ms": 742.5
+      "ms": 873.7
     },
     {
       "query": "browse/species.md",
       "label": "species",
       "status": "pass",
       "rows": 1,
-      "ms": 1329.1
+      "ms": 1354.1
     },
     {
       "query": "datasets/bottle.md",
       "label": "bottle measurements",
-      "status": "fail",
-      "ms": 2844.2,
-      "error": "Binder Error: Table \"c\" does not have a column named \"datetime_utc\"\n\nCandidate bindings: : \"datetime_start_utc\"\n\nLINE 17:   AND c.datetime_utc BETWEEN TIMESTAMP '2018-01-01' AND TIMESTAMP...\n               ^\nℹ Context: rapi_prepare\nℹ Error type: BINDER"
+      "status": "pass",
+      "rows": 500,
+      "ms": 7809.3
     },
     {
       "query": "datasets/ichthyo.md",
       "label": "ichthyoplankton",
-      "status": "fail",
-      "ms": 4341,
-      "error": "Binder Error: Table \"t\" does not have a column named \"time_start\"\n\nCandidate bindings: : \"datetime_start_utc\"\n\nLINE 22:   AND t.time_start BETWEEN TIMESTAMP '2014-01-01' AND TIMESTAMP...\n               ^\nℹ Context: rapi_prepare\nℹ Error type: BINDER"
+      "status": "pass",
+      "rows": 300,
+      "ms": 10826.8
     },
     {
       "query": "quick-facts/release.md",
       "label": "release facts",
-      "status": "fail",
-      "ms": 776.7,
-      "error": "Binder Error: Referenced column \"time_start\" not found in FROM clause!\nCandidate bindings: \"_ingested_at\", \"datetime_start_utc\", \"site_uuid\", \"tow_number\"\n\nLINE 7:   bio_date_rng  AS (SELECT min(time_start)::VARCHAR AS d0, max(time_start)::VARCHAR AS...\n                                       ^\nℹ Context: rapi_prepare\nℹ Error type: BINDER"
+      "status": "pass",
+      "rows": 10,
+      "ms": 3766.9
     },
     {
       "query": "spatial/bbox.md",
       "label": "casts in bbox",
-      "status": "fail",
-      "ms": 11.8,
-      "error": "Binder Error: Referenced column \"lon_dec\" not found in FROM clause!\nCandidate bindings: \"longitude\", \"order_occ\", \"inc_end\", \"bottom_depth_m\", \"int_c14\"\n\nLINE 11: WHERE lon_dec BETWEEN -125 AND -117\n               ^\nℹ Context: rapi_prepare\nℹ Error type: BINDER"
+      "status": "pass",
+      "rows": 288,
+      "ms": 1451.5
     },
     {
       "query": "sql-shell/shell.md",
       "label": "shell",
       "status": "pass",
       "rows": 1,
-      "ms": 1.6
+      "ms": 493.3
     },
     {
       "query": "temporal/date-range.md",
       "label": "casts in date range",
-      "status": "fail",
-      "ms": 502,
-      "error": "Binder Error: Referenced column \"datetime_utc\" not found in FROM clause!\nCandidate bindings: \"datetime_start_utc\", \"latitude\", \"data_type\", \"distance\", \"data_or\"\n\nLINE 10: WHERE datetime_utc BETWEEN TIMESTAMP '2018-01-01' AND TIMESTAMP...\n               ^\nℹ Context: rapi_prepare\nℹ Error type: BINDER"
+      "status": "pass",
+      "rows": 294,
+      "ms": 1261.4
     }
   ]
 }

--- a/release_database.qmd
+++ b/release_database.qmd
@@ -784,6 +784,26 @@ meta_paths <- Sys.glob(here("data/parquet/*/metadata.json"))
 
 meta_json_path <- file.path(dir_frozen, "metadata.json")
 if (length(meta_paths) > 0) {
+  # data-derived one-to-many measurement_type -> dataset(s) map. build the
+  # table -> owning-dataset(s) lookup from the ingest YAML's tables_owned (the
+  # `measurement_type` lookup table is excluded — its measurement_type column is
+  # the vocabulary, not measured rows), then scan each measurement table in the
+  # assembled DB for the types it actually reports.
+  table_datasets <- list()
+  for (key in names(ingest_yaml)) {
+    cc <- ingest_yaml[[key]]
+    for (e in cc$tables_owned %||% list())
+      table_datasets[[e$table]] <- union(table_datasets[[e$table]], key)
+    for (ad in cc$additional_datasets %||% list()) {
+      k2 <- paste0(ad$provider, "_", ad$dataset)
+      for (e in ad$tables_owned %||% list())
+        table_datasets[[e$table]] <- union(table_datasets[[e$table]], k2)
+    }
+  }
+  table_datasets[["measurement_type"]] <- NULL
+  meas_ds <- derive_measurement_type_datasets(con_wdl, table_datasets)
+  cat(glue("derived dataset membership for {length(meas_ds)} measurement types\n"))
+
   merge_metadata_json(
     paths                = meta_paths,
     output_path          = meta_json_path,
@@ -792,7 +812,8 @@ if (length(meta_paths) > 0) {
     release_columns_csv  = here("metadata/release_columns.csv"),
     measurement_type_csv = here("metadata/measurement_type.csv"),
     ingest_yaml          = ingest_yaml,
-    table_rows           = setNames(freeze_stats$rows, freeze_stats$table))
+    table_rows           = setNames(freeze_stats$rows, freeze_stats$table),
+    measurement_datasets = meas_ds)
 
   # enrich columns with data_type from the working DuckDB (so the schema
   # site can render types without spinning up DuckDB-WASM)


### PR DESCRIPTION
Wires `calcofi4db::derive_measurement_type_datasets()` (CalCOFI/calcofi4db#3) into the release: `release_database.qmd` builds the table→dataset map from the ingest YAML `tables_owned` (excluding the `measurement_type` vocab table) and passes the data-derived map to `merge_metadata_json()`, so the schema site's per-measurement dataset filter reflects reality.

Regenerated `data/releases/v2026.06.26/metadata.json` (and re-uploaded to GCS with `no-cache`): `measurement_types[].datasets` are now JSON arrays with data-derived membership. `test_results.json` records the v2026.06.26 query gate passing (9/0/4) — which is what promoted `latest.txt` to v2026.06.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)