### PR TITLE
test_release: dispatch query bump-default-version on promotion

### DIFF
--- a/test_release.qmd
+++ b/test_release.qmd
@@ -337,6 +337,25 @@ put_gcs_file(latest_local,
 message(glue(
   "PROMOTED {release_version}: {n_pass} passed, {n_skip} skipped, ",
   "0 failed. latest.txt is now {release_version}."))
+
+# nudge the query site to adopt the new default_version now (previously a
+# 6-hourly cron poll): dispatch CalCOFI/query's bump-default-version workflow,
+# which mirrors latest.txt -> _config.yml and triggers a Pages redeploy. Gated
+# here on the all-pass promotion, so the site never points at a release whose
+# queries haven't been validated. Non-fatal — a missing gh just means the bump
+# waits for a manual `gh workflow run`.
+gh_bin <- Sys.which("gh")
+if (nzchar(gh_bin)) {
+  disp <- system2(gh_bin,
+    c("workflow", "run", "bump-default-version.yml", "--repo", "CalCOFI/query"),
+    stdout = TRUE, stderr = TRUE)
+  if (!identical(attr(disp, "status") %||% 0L, 0L))
+    warning(glue("query bump dispatch failed: {paste(disp, collapse = '; ')}"))
+  else
+    message("dispatched CalCOFI/query bump-default-version workflow")
+} else {
+  message("gh not found; CalCOFI/query default_version needs a manual bump dispatch")
+}
 ```
 
 ## Cleanup


### PR DESCRIPTION
Makes the query site's `default_version` update **event-driven**: in `test_release.qmd`'s `promote` chunk (the all-pass path that writes `latest.txt`), dispatch CalCOFI/query's `bump-default-version` workflow via `gh workflow run`. The site adopts the new default within minutes instead of waiting on the (now-removed) 6-hourly cron, and only after every pre-baked query has passed against the release. Non-fatal — a missing `gh` just logs that a manual dispatch is needed.

Pairs with CalCOFI/query#5 (which makes that workflow dispatch-only and fixes a long-standing malformed-YAML bug that meant it never actually ran).

🤖 Generated with [Claude Code](https://claude.com/claude-code)